### PR TITLE
fixup: syntax error

### DIFF
--- a/src/nerorunner.cpp
+++ b/src/nerorunner.cpp
@@ -104,12 +104,12 @@ int NeroRunner::StartShortcut(const QString &hash, const bool &prefixAlreadyRunn
             env.insert("PROTON_ENABLE_NVAPI", "1");
 
         if(!settings->value("Shortcuts--"+hash+"/LimitGLextensions").toString().isEmpty()) {
-            if(settings->value("Shortcuts--"+hash+"LimitGLextensions").toBool()) env.insert("PROTON_OLD_GL_STRING", "1");
+            if(settings->value("Shortcuts--"+hash+"/LimitGLextensions").toBool()) env.insert("PROTON_OLD_GL_STRING", "1");
         } else if(settings->value("PrefixSettings/LimitGLextensions").toBool())
             env.insert("PROTON_OLD_GL_STRING", "1");
 
         if(!settings->value("Shortcuts--"+hash+"/VKcapture").toString().isEmpty()) {
-            if(settings->value("Shortcuts--"+hash+"VKcapture").toBool()) env.insert("OBS_VKCAPTURE", "1");
+            if(settings->value("Shortcuts--"+hash+"/VKcapture").toBool()) env.insert("OBS_VKCAPTURE", "1");
         } else if(settings->value("PrefixSettings/VKcapture").toBool())
             env.insert("OBS_VKCAPTURE", "1");
 


### PR DESCRIPTION
Fixed `Set Limited GL Extensions` and `Enable OBS Vulkan Capture` option's unintended behaviours due to typo.

<sub>This caused me a lot of headaches when trying to make a new option</sub>