### PR TITLE
Add Force Integrated GPU option

### DIFF
--- a/src/nerofs.cpp
+++ b/src/nerofs.cpp
@@ -290,6 +290,7 @@ void NeroFS::AddNewPrefix(const QString &newPrefix, const QString &runner)
     prefixCfg->setValue("GamescopeFilter", NeroConstant::GSfilterLinear);
     //prefixCfg->setValue("GamescopeFilterStrength", 0);
     prefixCfg->setValue("DLLoverrides", {""});
+    prefixCfg->setValue("UseiGPU", false);
     prefixCfg->setValue("LimitGLextensions", false);
     prefixCfg->setValue("DebugOutput", NeroConstant::DebugDisabled);
     prefixCfg->setValue("FileSyncMode", NeroConstant::Fsync);

--- a/src/nerofs.cpp
+++ b/src/nerofs.cpp
@@ -290,7 +290,7 @@ void NeroFS::AddNewPrefix(const QString &newPrefix, const QString &runner)
     prefixCfg->setValue("GamescopeFilter", NeroConstant::GSfilterLinear);
     //prefixCfg->setValue("GamescopeFilterStrength", 0);
     prefixCfg->setValue("DLLoverrides", {""});
-    prefixCfg->setValue("UseiGPU", false);
+    prefixCfg->setValue("ForceiGPU", false);
     prefixCfg->setValue("LimitGLextensions", false);
     prefixCfg->setValue("DebugOutput", NeroConstant::DebugDisabled);
     prefixCfg->setValue("FileSyncMode", NeroConstant::Fsync);

--- a/src/neroprefixsettings.cpp
+++ b/src/neroprefixsettings.cpp
@@ -236,7 +236,7 @@ void NeroPrefixSettingsWindow::LoadSettings()
     // advanced tab
     ui->debugBox->setCurrentIndex(settings.value("DebugOutput").toInt());
     ui->fileSyncBox->setCurrentIndex(settings.value("FileSyncMode").toInt());
-    SetCheckboxState("UseiGPU",            ui->toggleiGPU);
+    SetCheckboxState("ForceiGPU",            ui->toggleiGPU);
     SetCheckboxState("LimitGLextensions",  ui->toggleLimitGL);
     SetCheckboxState("NoD8VK",             ui->toggleNoD8VK);
     SetCheckboxState("ForceWineD3D",       ui->toggleWineD3D);

--- a/src/neroprefixsettings.cpp
+++ b/src/neroprefixsettings.cpp
@@ -236,6 +236,7 @@ void NeroPrefixSettingsWindow::LoadSettings()
     // advanced tab
     ui->debugBox->setCurrentIndex(settings.value("DebugOutput").toInt());
     ui->fileSyncBox->setCurrentIndex(settings.value("FileSyncMode").toInt());
+    SetCheckboxState("UseiGPU",            ui->toggleiGPU);
     SetCheckboxState("LimitGLextensions",  ui->toggleLimitGL);
     SetCheckboxState("NoD8VK",             ui->toggleNoD8VK);
     SetCheckboxState("ForceWineD3D",       ui->toggleWineD3D);

--- a/src/neroprefixsettings.ui
+++ b/src/neroprefixsettings.ui
@@ -1603,7 +1603,7 @@
              <string>Force Integrated GPU</string>
             </property>
             <property name="isFor" stdset="0">
-             <string>UseiGPU</string>
+             <string>ForceiGPU</string>
             </property>
            </widget>
           </item>

--- a/src/neroprefixsettings.ui
+++ b/src/neroprefixsettings.ui
@@ -1591,6 +1591,22 @@
             </item>
            </widget>
           </item>
+          <item row="2" column="1"  colspan="2" alignment="Qt::AlignmentFlag::AlignCenter">
+           <widget class="QCheckBox" name="toggleiGPU">
+            <property name="whatsThis">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled, forces programs to run via the integrated graphics card by fully hiding any other graphics cards you may have in your system. This is done before running the main program, therefore any other programs you might start afterwards within the main program &lt;span style=&quot; font-weight:700;&quot;&gt;will also be forced to use the integrated graphics card.&lt;/p&gt;&lt;p&gt; This option is mainly intended for usage with laptops where battery life and heat management is important.&lt;/p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;If unsure, keep disabled&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="accessibleName">
+             <string>Force Usage of Integrated Graphics Card</string>
+            </property>
+            <property name="text">
+             <string>Force Integrated GPU</string>
+            </property>
+            <property name="isFor" stdset="0">
+             <string>UseiGPU</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -1948,6 +1964,7 @@
   <tabstop>postRunButton</tabstop>
   <tabstop>prefixEnvVars</tabstop>
   <tabstop>debugBox</tabstop>
+  <tabstop>toggleiGPU</tabstop>
   <tabstop>prefixInstallDiscordRPC</tabstop>
   <tabstop>prefixDrivesBtn</tabstop>
   <tabstop>prefixRegeditBtn</tabstop>

--- a/src/neroprefixsettings.ui
+++ b/src/neroprefixsettings.ui
@@ -760,7 +760,23 @@
             </layout>
            </widget>
           </item>
-          <item row="0" column="0" colspan="2">
+          <item row="0" column="0"  colspan="2">
+           <widget class="QCheckBox" name="toggleiGPU">
+            <property name="whatsThis">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled, forces programs to run via the integrated graphics card by fully hiding any other graphics cards you may have in your system. This is done before running the main program, therefore any other programs you might start afterwards within the main program &lt;span style=&quot; font-weight:700;&quot;&gt;will also be forced to use the integrated graphics card.&lt;/p&gt;&lt;p&gt; This option is mainly intended for usage with laptops where battery life and heat management is important and may or &lt;span style=&quot; font-weight:700;&quot;&gt; may not work depending on your desktop setup.&lt;/p&gt;If unsure, use only if you are sure you have a two GPU setup and you can use them both.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="accessibleName">
+             <string>Force Usage of Integrated Graphics Card</string>
+            </property>
+            <property name="text">
+             <string>Force Integrated GPU</string>
+            </property>
+            <property name="isFor" stdset="0">
+             <string>ForceiGPU</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="2">
            <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="0,0">
             <item>
              <widget class="QCheckBox" name="toggleNVAPI">
@@ -1589,22 +1605,6 @@
               <string>Full Debug Output</string>
              </property>
             </item>
-           </widget>
-          </item>
-          <item row="2" column="1"  colspan="2" alignment="Qt::AlignmentFlag::AlignCenter">
-           <widget class="QCheckBox" name="toggleiGPU">
-            <property name="whatsThis">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled, forces programs to run via the integrated graphics card by fully hiding any other graphics cards you may have in your system. This is done before running the main program, therefore any other programs you might start afterwards within the main program &lt;span style=&quot; font-weight:700;&quot;&gt;will also be forced to use the integrated graphics card.&lt;/p&gt;&lt;p&gt; This option is mainly intended for usage with laptops where battery life and heat management is important.&lt;/p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;If unsure, keep disabled&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="accessibleName">
-             <string>Force Usage of Integrated Graphics Card</string>
-            </property>
-            <property name="text">
-             <string>Force Integrated GPU</string>
-            </property>
-            <property name="isFor" stdset="0">
-             <string>ForceiGPU</string>
-            </property>
            </widget>
           </item>
          </layout>

--- a/src/nerorunner.cpp
+++ b/src/nerorunner.cpp
@@ -113,6 +113,11 @@ int NeroRunner::StartShortcut(const QString &hash, const bool &prefixAlreadyRunn
         } else if(settings->value("PrefixSettings/VKcapture").toBool())
             env.insert("OBS_VKCAPTURE", "1");
 
+        if(!settings->value("Shortcuts--"+hash+"/UseiGPU").toString().isEmpty()) {
+            if(settings->value("Shortcuts--"+hash+"/UseiGPU").toBool()) env.insert("MESA_VK_DEVICE_SELECT_FORCE_DEFAULT_DEVICE", "1");
+        } else if(settings->value("PrefixSettings/UseiGPU").toBool())
+            env.insert("MESA_VK_DEVICE_SELECT_FORCE_DEFAULT_DEVICE", "1");
+
         if(settings->value("Shortcuts--"+hash+"/LimitFPS").toInt())
             env.insert("DXVK_FRAME_RATE", QString::number(settings->value("Shortcuts--"+hash+"/LimitFPS").toInt()));
 
@@ -591,6 +596,8 @@ int NeroRunner::StartOnetime(const QString &path, const bool &prefixAlreadyRunni
         env.insert("PROTON_OLD_GL_STRING", "1");
     if(settings->value("PrefixSettings/VKcapture").toBool())
         env.insert("OBS_VKCAPTURE", "1");
+    if(settings->value("PrefixSettings/UseiGPU").toBool())
+        env.insert("MESA_VK_DEVICE_SELECT_FORCE_DEFAULT_DEVICE", "1");
 
     switch(settings->value("PrefixSettings/FileSyncMode").toInt()) {
     // ntsync SHOULD be better in all scenarios compared to other sync options, but requires kernel 6.14+ and GE-Proton10-9+

--- a/src/nerorunner.cpp
+++ b/src/nerorunner.cpp
@@ -113,9 +113,9 @@ int NeroRunner::StartShortcut(const QString &hash, const bool &prefixAlreadyRunn
         } else if(settings->value("PrefixSettings/VKcapture").toBool())
             env.insert("OBS_VKCAPTURE", "1");
 
-        if(!settings->value("Shortcuts--"+hash+"/UseiGPU").toString().isEmpty()) {
-            if(settings->value("Shortcuts--"+hash+"/UseiGPU").toBool()) env.insert("MESA_VK_DEVICE_SELECT_FORCE_DEFAULT_DEVICE", "1");
-        } else if(settings->value("PrefixSettings/UseiGPU").toBool())
+        if(!settings->value("Shortcuts--"+hash+"/ForceiGPU").toString().isEmpty()) {
+            if(settings->value("Shortcuts--"+hash+"/ForceiGPU").toBool()) env.insert("MESA_VK_DEVICE_SELECT_FORCE_DEFAULT_DEVICE", "1");
+        } else if(settings->value("PrefixSettings/ForceiGPU").toBool())
             env.insert("MESA_VK_DEVICE_SELECT_FORCE_DEFAULT_DEVICE", "1");
 
         if(settings->value("Shortcuts--"+hash+"/LimitFPS").toInt())
@@ -596,7 +596,7 @@ int NeroRunner::StartOnetime(const QString &path, const bool &prefixAlreadyRunni
         env.insert("PROTON_OLD_GL_STRING", "1");
     if(settings->value("PrefixSettings/VKcapture").toBool())
         env.insert("OBS_VKCAPTURE", "1");
-    if(settings->value("PrefixSettings/UseiGPU").toBool())
+    if(settings->value("PrefixSettings/ForceiGPU").toBool())
         env.insert("MESA_VK_DEVICE_SELECT_FORCE_DEFAULT_DEVICE", "1");
 
     switch(settings->value("PrefixSettings/FileSyncMode").toInt()) {


### PR DESCRIPTION
Added new option to force usage of iGPU. Closes #51 

This was my attempt at copying how other ui widgets were implemented, more than likely has some bad code conventions, so the `neroprefixsettings.ui` file needs a thorough review.

For the actual feature, the environment variable `MESA_VK_DEVICE_SELECT_FORCE_DEFAULT_DEVICE` seems to work the best out of the ones I've tried, working with intel/nvidia, amd/nvidia and amd/amd systems. Should still be built and tested to see if it has any issues in other system configurations.