### PR TITLE
feat: add .cmd support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
             arguments.append(argv[i]);
 
         // One-time runner (executable only) - prompt user for prefix
-        if(argc < 3 && (arguments.last().endsWith(".exe") || arguments.last().endsWith(".msi") || arguments.last().endsWith(".bat"))) {
+        if(argc < 3 && (arguments.last().endsWith(".exe") || arguments.last().endsWith(".msi") || arguments.last().endsWith(".bat") || arguments.last().endsWith(".cmd"))) {
             printf("Requested to open file!\n");
 
             if(NeroFS::InitPaths()) {

--- a/src/neromanager.cpp
+++ b/src/neromanager.cpp
@@ -446,7 +446,7 @@ void NeroManagerWindow::on_addButton_clicked()
         QString newApp(QFileDialog::getOpenFileName(this,
                                                     "Select a Windows Executable",
                                                     NeroFS::GetPrefixesPath().absoluteFilePath(NeroFS::GetCurrentPrefix()+"/drive_c"),
-        "Compatible Windows Files (*.bat *.exe *.msi);;Windows Batch Script Files (*.bat);;Windows Executable (*.exe);;Windows Installer Package (*.msi)",
+        "Compatible Windows Files (*.bat *.cmd *.exe *.msi);;Windows Batch Script Files (*.bat *.cmd);;Windows Executable (*.exe);;Windows Installer Package (*.msi)",
                                                     nullptr,
                                                     QFileDialog::DontResolveSymlinks));
 
@@ -681,7 +681,7 @@ void NeroManagerWindow::on_oneTimeRunBtn_clicked()
     QString oneTimeApp(QFileDialog::getOpenFileName(this,
                                                     "Select an Executable to Start in Prefix",
                                                     oneTimeLastPath.isEmpty() ? NeroFS::GetPrefixesPath().absoluteFilePath(NeroFS::GetCurrentPrefix()+"/drive_c") : oneTimeLastPath,
-    "Compatible Windows Executables (*.bat *.exe *.msi);;Windows Batch Script Files (*.bat);;Windows Portable Executable (*.exe);;Windows Installer Package (*.msi)",
+    "Compatible Windows Executables (*.bat *.cmd *.exe *.msi);;Windows Batch Script Files (*.bat *.cmd);;Windows Portable Executable (*.exe);;Windows Installer Package (*.msi)",
                                                     nullptr,
                                                     QFileDialog::DontResolveSymlinks));
 

--- a/src/neroprefixsettings.cpp
+++ b/src/neroprefixsettings.cpp
@@ -410,7 +410,7 @@ void NeroPrefixSettingsWindow::on_shortcutPathBtn_clicked()
                                                   "Select a Windows Executable",
                                                   ui->shortcutPath->text().replace("C:/",
                                                                                    NeroFS::GetPrefixesPath().canonicalPath()+'/'+NeroFS::GetCurrentPrefix()+"/drive_c/"),
-    "Compatible Windows Executables (*.bat *.exe *.msi);;Windows Batch Script Files (*.bat);;Windows Portable Executable (*.exe);;Windows Installer Package (*.msi)",
+    "Compatible Windows Executables (*.bat *.cmd *.exe *.msi);;Windows Batch Script Files (*.bat *.cmd);;Windows Portable Executable (*.exe);;Windows Installer Package (*.msi)",
                                                   nullptr,
                                                   QFileDialog::DontResolveSymlinks);
     if(!newApp.isEmpty()) {

--- a/src/neroshortcut.cpp
+++ b/src/neroshortcut.cpp
@@ -91,7 +91,7 @@ void NeroShortcutWizard::on_selectBox_clicked()
                                                   "Select a Windows Executable",
                                                   ui->appPath->text().replace("C:/",
                                                                               NeroFS::GetPrefixesPath().canonicalPath()+'/'+NeroFS::GetCurrentPrefix()+"/drive_c/"),
-    "Compatible Windows Executables (*.bat *.exe *.msi);;Windows Batch Script Files (*.bat);;Windows Portable Executable (*.exe);;Windows Installer Package (*.msi)",
+    "Compatible Windows Executables (*.bat *.cmd *.exe *.msi);;Windows Batch Script Files (*.bat *.cmd);;Windows Portable Executable (*.exe);;Windows Installer Package (*.msi)",
                                                   nullptr,
                                                   QFileDialog::DontResolveSymlinks);
 


### PR DESCRIPTION
Adds .cmd to list of detected executable types. Ref: https://en.wikipedia.org/wiki/Batch_file#Filename_extensions

Discovered this installing [SoFplus](http://sof1.megalag.org/sofplus/), which has a .cmd installation file.