### PR TITLE
Auto-fill shortcut name on shortcut wizard

### DIFF
--- a/src/neroshortcut.cpp
+++ b/src/neroshortcut.cpp
@@ -44,6 +44,11 @@ NeroShortcutWizard::NeroShortcutWizard(QWidget *parent, const QString &newAppPat
 
     NeroIcoExtractor::CheckIcoCache(QDir(NeroFS::GetPrefixesPath().path()+'/'+NeroFS::GetCurrentPrefix()));
 
+    // set the shortcut name field to the exe name
+    QString newAppNameWithExtension = newAppPath.right((newAppPath.length() - 1) - newAppPath.lastIndexOf("/"));
+    QString newAppName = newAppNameWithExtension.left(newAppNameWithExtension.lastIndexOf("."));
+    ui->shortcutName->setText(newAppName);
+
     QGuiApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
     appIcon = NeroIcoExtractor::GetIcon(newAppPath);
     QGuiApplication::restoreOverrideCursor();


### PR DESCRIPTION
Added a simple string parse to get the executable name from executable paths, then auto-filled the `shortcutName` box with it.

Tested with executables that have a `⁄` or `.` in their name and in both cases there doesn't seem to be any issues.