### PR TITLE
feat: add version flag

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@ void PrintHelp()
         "  --prefix \"Prefix Name\"        Run executable within \"Prefix Name\"\n"
         "  --list                        List contents of prefix specified with --prefix\n"
         "  --shortcut \"Shortcut Name\"    Launch a specific shortcut from specified --prefix, according to the prefix's current settings.\n"
+        "  -v, --version                 Show version information.\n"
         "  -h, --help                    Show this help. Helpful, huh? c:\n"
         );
 }
@@ -139,6 +140,10 @@ int main(int argc, char *argv[])
                 printf("Nero cannot run without a home directory set! Aborting...\n");
                 return 1;
             }
+        // Version printout
+        } else if(argc < 3 && (arguments.last() == "-v" || arguments.last() == "--version")) {
+            printf("nero-umu %s \"%s\"\n", NERO_VERSION, NERO_CODENAME);
+            return 0;
         // Help printout
         } else if(argc < 3 && (arguments.last() == "-h" || arguments.last() == "--help")) {
             PrintHelp();


### PR DESCRIPTION
Adds a version flag to the CLI. Main motivation is add some validation to the nix package, but this should probably exist anyway.

stdout:

```
nero-umu 1.2.0 "Kelvin"
```

help stdout:

```
usage: nero-umu [--prefix "Prefix Name" [--list] [--shortcut "Shortcut Name"]] executable [arg1] [arg2] [...]

Nero-umu CLI: Launch Windows executables within a Nero-managed Prefix

options:
  --prefix "Prefix Name"        Run executable within "Prefix Name"
  --list                        List contents of prefix specified with --prefix
  --shortcut "Shortcut Name"    Launch a specific shortcut from specified --prefix, according to the prefix's current settings.
  -v, --version                 Show version information.
  -h, --help                    Show this help. Helpful, huh? c:
```
